### PR TITLE
Do not compute stats on non-saved products

### DIFF
--- a/statsstock.php
+++ b/statsstock.php
@@ -67,6 +67,7 @@ class StatsStock extends Module
 					'.Shop::addSqlAssociation('product_attribute', 'pa').'
 					WHERE p.id_product = pa.id_product
 					AND product_attribute_shop.wholesale_price != 0
+					AND p.state = '. Product::STATE_SAVED . '
 				), product_shop.wholesale_price) as wholesale_price,
 				IFNULL(stock.quantity, 0) as quantity
 				FROM '._DB_PREFIX_.'product p
@@ -74,8 +75,7 @@ class StatsStock extends Module
 				INNER JOIN '._DB_PREFIX_.'product_lang pl
 					ON (p.id_product = pl.id_product AND pl.id_lang = '.(int)$this->context->language->id.Shop::addSqlRestrictionOnLang('pl').')
 				'.Product::sqlStock('p', 0).'
-				WHERE 1 = 1
-				'.$filter;
+				WHERE p.state = '. Product::STATE_SAVED . $filter;
 		$products = Db::getInstance()->executeS($sql);
 
 		foreach ($products as $key => $p)


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | The stats should not be computed on non-saved products
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1168
| How to test?  |  <ul><li>Create & save 1 product</li><li>Create 1 product but do not save it</li><li>Go to Statistics > Available Quantities</li><li>You should not see the product you didn't save</li></ul>