### PR TITLE
Do not use hook AdminStatsModules alias, use displayAdminStatsModules & Bump version to 2.0.1

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>statsstock</name>
 	<displayName><![CDATA[Available quantities]]></displayName>
-	<version><![CDATA[2.0.0]]></version>
+	<version><![CDATA[2.0.1]]></version>
 	<description><![CDATA[Adds a tab showing the quantity of available products for sale to the Stats dashboard.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/statsstock.php
+++ b/statsstock.php
@@ -36,7 +36,7 @@ class statsstock extends Module
     {
         $this->name = 'statsstock';
         $this->tab = 'administration';
-        $this->version = '2.0.0';
+        $this->version = '2.0.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -49,10 +49,10 @@ class statsstock extends Module
 
     public function install()
     {
-        return parent::install() && $this->registerHook('AdminStatsModules');
+        return parent::install() && $this->registerHook('displayAdminStatsModules');
     }
 
-    public function hookAdminStatsModules()
+    public function hookDisplayAdminStatsModules()
     {
         if (Tools::isSubmit('submitCategory')) {
             $this->context->cookie->statsstock_id_category = Tools::getValue('statsstock_id_category');

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/upgrade/upgrade-2.0.1.php
+++ b/upgrade/upgrade-2.0.1.php
@@ -1,0 +1,33 @@
+
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+/**
+ * @param Module $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_1$module)
+{
+    $module->unregisterHook('AdminStatsModules');
+    $module->registerHook('displayAdminStatsModules');
+
+    return true;
+}

--- a/upgrade/upgrade-2.0.1.php
+++ b/upgrade/upgrade-2.0.1.php
@@ -24,7 +24,7 @@
  *
  * @return bool
  */
-function upgrade_module_2_0_1$module)
+function upgrade_module_2_0_1($module)
 {
     $module->unregisterHook('AdminStatsModules');
     $module->registerHook('displayAdminStatsModules');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Do not use hook AdminStatsModules alias, use displayAdminStatsModules
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | n/d
| Possible impacts? | n/d

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
