### PR TITLE
Provide absolute URL to fix routing issues

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -71,14 +71,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/statsstock.php
+++ b/statsstock.php
@@ -57,7 +57,7 @@ class statsstock extends Module
             $this->context->cookie->statsstock_id_category = Tools::getValue('statsstock_id_category');
         }
 
-				$ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
+	$ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
         $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
         $filter = ((int) $this->context->cookie->statsstock_id_category ? ' AND p.id_product IN (SELECT cp.id_product FROM ' . _DB_PREFIX_ . 'category_product cp WHERE cp.id_category = ' . (int) $this->context->cookie->statsstock_id_category . ')' : '');
 

--- a/statsstock.php
+++ b/statsstock.php
@@ -57,7 +57,6 @@ class statsstock extends Module
             $this->context->cookie->statsstock_id_category = Tools::getValue('statsstock_id_category');
         }
 
-
         $ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
         $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
         $filter = ((int) $this->context->cookie->statsstock_id_category ? ' AND p.id_product IN (SELECT cp.id_product FROM ' . _DB_PREFIX_ . 'category_product cp WHERE cp.id_category = ' . (int) $this->context->cookie->statsstock_id_category . ')' : '');

--- a/statsstock.php
+++ b/statsstock.php
@@ -57,7 +57,8 @@ class statsstock extends Module
             $this->context->cookie->statsstock_id_category = Tools::getValue('statsstock_id_category');
         }
 
-	$ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
+
+        $ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
         $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
         $filter = ((int) $this->context->cookie->statsstock_id_category ? ' AND p.id_product IN (SELECT cp.id_product FROM ' . _DB_PREFIX_ . 'category_product cp WHERE cp.id_category = ' . (int) $this->context->cookie->statsstock_id_category . ')' : '');
 

--- a/statsstock.php
+++ b/statsstock.php
@@ -57,7 +57,7 @@ class statsstock extends Module
             $this->context->cookie->statsstock_id_category = Tools::getValue('statsstock_id_category');
         }
 
-        $ru = AdminController::$currentIndex . '&module=' . $this->name . '&token=' . Tools::getValue('token');
+				$ru = $this->context->link->getAdminLink('AdminStats', true) . '&module=' . $this->name;
         $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
         $filter = ((int) $this->context->cookie->statsstock_id_category ? ' AND p.id_product IN (SELECT cp.id_product FROM ' . _DB_PREFIX_ . 'category_product cp WHERE cp.id_category = ' . (int) $this->context->cookie->statsstock_id_category . ')' : '');
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Provide absolute URL to fix routing issues. Fixes potential issues coming from relative URLs not being reliable after symfony migration. See https://github.com/PrestaShop/PrestaShop/issues/39185. cc @Touxten 
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/39185
| Sponsor company   | TRENDO s.r.o.
| How to test?      | Just test the module can be configured correctly and loads in the backoffice, so we didn't break anything or have some typo. (On nginx server, this could be problematic.)
